### PR TITLE
Add optional descriminator for usernames

### DIFF
--- a/ejb/src/main/java/org/keycloak/social/discord/DiscordIdentityProvider.java
+++ b/ejb/src/main/java/org/keycloak/social/discord/DiscordIdentityProvider.java
@@ -69,7 +69,12 @@ public class DiscordIdentityProvider extends AbstractOAuth2IdentityProvider<Disc
     protected BrokeredIdentityContext extractIdentityFromProfile(EventBuilder event, JsonNode profile) {
         BrokeredIdentityContext user = new BrokeredIdentityContext(getJsonProperty(profile, "id"));
 
-        user.setUsername(getJsonProperty(profile, "username") + "#" + getJsonProperty(profile, "discriminator"));
+        if (getConfig().getAddDescriminator()) {
+            user.setUsername(getJsonProperty(profile, "username") + "#" + getJsonProperty(profile, "discriminator"));
+        }
+        else {
+            user.setUsername(getJsonProperty(profile, "username"));
+        }
         user.setEmail(getJsonProperty(profile, "email"));
         user.setIdpConfig(getConfig());
         user.setIdp(this);

--- a/ejb/src/main/java/org/keycloak/social/discord/DiscordIdentityProviderConfig.java
+++ b/ejb/src/main/java/org/keycloak/social/discord/DiscordIdentityProviderConfig.java
@@ -58,6 +58,15 @@ public class DiscordIdentityProviderConfig extends OAuth2IdentityProviderConfig 
         return Collections.emptySet();
     }
 
+    public boolean getAddDescriminator() {
+        String setting = getConfig().get("addDescriminator");
+        return setting != null && (setting == "true" || setting == "on");
+    }
+
+    public void setAddDescriminator(boolean value) {
+        getConfig().put("addDescriminator", value ? "true" : "false");
+    }
+
     public void setPrompt(String prompt) {
         getConfig().put("prompt", prompt);
     }

--- a/ejb/src/main/resources/theme-resources/messages/admin-messages_en.properties
+++ b/ejb/src/main/resources/theme-resources/messages/admin-messages_en.properties
@@ -1,7 +1,9 @@
 discord-client-id=Client Id
 discord-client-secret=Client Secret
 discord-allowed-guilds=Guild Id(s) to allow federation
+discord-add-descriminator=Add descriminator to the username
 discord.client-id.tooltip=Client Id for the application you created in your discord developer portal.
 discord.client-secret.tooltip=Client Secret for the application that you created in your discord developer portal.
 discord.allowed-guilds.tooltip=If you want to allow federation for specific guild, enter the guild id. Please use a comma as a separator for multiple guilds.
 discord.default-scopes.tooltip=The scopes to be sent when asking for authorization. See discord OAuth2 documentation for possible values. If you do not specify anything, scope defaults to 'identify email' In addition, plus 'guilds' if you enter guild id(s) to allow federation.
+discord.add-descriminator.tooltip=If you select this option the username will always be appended with the discord descriminator.

--- a/ejb/src/main/resources/theme-resources/resources/partials/realm-identity-provider-discord-ext.html
+++ b/ejb/src/main/resources/theme-resources/resources/partials/realm-identity-provider-discord-ext.html
@@ -5,3 +5,10 @@
     </div>
     <kc-tooltip>{{:: 'discord.allowed-guilds.tooltip' | translate}}</kc-tooltip>
 </div>
+<div class="form-group clearfix">
+    <label class="col-md-2 control-label" for="addDescriminator">{{:: 'discord-add-descriminator' | translate }}</label>
+    <div class="col-md-6">
+        <input ng-model="identityProvider.config.addDescriminator" id="addDescriminator" onoffswitch on-text="{{:: 'onText' | translate}}" off-text="{{:: 'offText' || translate}}" />
+    </div>
+    <kc-tooltip>{{:: 'discord.add-descriminator.tooltip' | translate}}</kc-tooltip>
+</div>


### PR DESCRIPTION
Some users do not want to constantly append the descriminator to the username. Therefore, there is now an option where you can choose whether you want this or not.

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>